### PR TITLE
remplacement de la gem dartsass-rails par sassc-rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,6 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
-# Ignore asset builds
-/app/assets/builds/*
-!/app/assets/builds/.keep
-
 # Other files to ignore
 .DS_Store
 .ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'dotenv-rails'
 gem 'devise'
 gem 'stripe', "~> 5.53"
 gem "aws-sdk-s3"
-gem "dartsass-rails", "~> 0.4.1"
 
 group :development do
   gem 'better_errors'
@@ -60,7 +59,7 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem "bootsnap", require: false
 
 # Use Sass to process CSS
-# gem "sassc-rails"
+gem "sassc-rails"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,0 @@
-web: bin/rails server -p 3000
-css: bin/rails dartsass:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,4 @@
 //= link_tree ../images
-//= link_tree ../builds
+//= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js

--- a/bin/dev
+++ b/bin/dev
@@ -1,8 +1,0 @@
-#!/usr/bin/env sh
-
-if ! gem list foreman -i --silent; then
-  echo "Installing foreman..."
-  gem install foreman
-fi
-
-exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
Roolback de ma PR d'hier = changement de gem pour gérer le pré-processing de Sass dans Rails
Donc remplacement de la gem `dartsass-rails` (à jour part rapport à Sass mais malheureusement n'est pas branché à Sprocket donc pas de communication avec AssetPipeline 😭) par `sassc-rails` (gem officielle mais bientôt obsolète car n'intègre pas le dernier moteur de build conseillé par Sass, aka dart-sass)

**En ce qui vous concerne directement :**
Pas de changement majeur, tout ceci est de la tambouille interne de gestion des builds Sass. Le seul truc qui change c'est que vous n'aurez en fait **plus besoin de la commande de build** indiquée hier.
Cette fois-ci, c'est bien l'AssetPipeline qui gèrera comme un grand les builds de CSS en arrière-plan, si ya des modif dans les fichiers sass.